### PR TITLE
Fix font size in additional text

### DIFF
--- a/src/list/list.md
+++ b/src/list/list.md
@@ -27,7 +27,7 @@ eleventyComputed:
     <li class="list__item">
         <p class="text--primary">{{ item.primary }}</p>
         <p class="text--secondary">{{ item.secondary }}</p>
-        <p class="text--additional">{{ item.additionalText | renderContent: "md" }}</p>
+        <div class="text--additional">{{ item.additionalText | renderContent: "md" }}</div>
     </li>
     {%- endfor -%}
     </ol>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -86,14 +86,22 @@ body > * + * {
 }
 
 .list__item + .list__item {
-	margin-top: 2rem;
+	margin-block-start: 1.5rem;
 }
 
-.list__item > p {
+.list__item > * {
 	margin: 0;
 	padding: 0;
 }
 
-.list__item > p + p {
-	margin-top: 0.5rem;
+/*
+	Additional text uses a div container with a child paragraph because of Markdown rendering.
+    This clears any internal paragraph margin.
+ */
+.list__item > * > p {
+	margin-block-start: 0;
+}
+
+.list__item > * + * {
+	margin-block-start: 0.5rem;
 }


### PR DESCRIPTION
This issue happened because the `renderContent: "md"` filter usage was causing an extra paragraph in the markup output, causing styles to not apply.

Also tweaks list styles a bit, because I couldn't help myself.