### PR TITLE
Add sticky positioning of list-item essential text

### DIFF
--- a/src/list/list.md
+++ b/src/list/list.md
@@ -31,7 +31,7 @@ eleventyComputed:
     {%- for item in listItems -%}
     <li class="list__item">
         <div class="list__item__container">
-            <div data-words-box>
+            <div data-words-box data-item-essential>
                 <p class="text--primary">{{ item.primary }}</p>
                 <p class="text--secondary">{{ item.secondary }}</p>
             </div>
@@ -55,7 +55,7 @@ eleventyComputed:
     {%- for item in exclusions -%}
     <li class="list__item item-exclusion">
         <div class="list__item__container">
-            <div data-words-box>
+            <div data-words-box data-item-essential>
                 <p class="text--primary">{{ item.primary }}</p>
                 <p class="text--secondary">{{ item.secondary }}</p>
             </div>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -2,6 +2,8 @@
 @import url('fonts.css');
 
 :root {
+	--bg-color: #F8F8F8;
+
 	--primary-size: 1.75rem;
 	--primary-color: black;
 
@@ -24,6 +26,8 @@ body {
 	font-family: var(--font-family--sans-serif);
 	margin: 0;
 	padding: clamp(2rem, 5svw, 3rem);
+
+	background-color: var(--bg-color);
 
 	max-width: var(--content-max-width);
 }
@@ -122,4 +126,15 @@ body > * + * {
 .item-exclusion::marker {
 	font-size: var(--secondary-size);
 	content: '⛔ ';
+}
+
+[data-item-essential] {
+	--fade-distance: 1rem;
+	padding-bottom: var(--fade-distance);
+
+	position: sticky;
+	top: 0;
+
+    --bg-distance: calc(90% + var(--fade-distance));
+	background-image: linear-gradient(to bottom, var(--bg-color) 85%, transparent);
 }


### PR DESCRIPTION
This allows the essential text (the primary and secondary item lines of text) to stay at the top of the viewport until the next item is reached. It works great on mobile.