### PR TITLE
Add deploy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist-deploy
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "npm run eleventy",
     "clean": "npx rimraf dist/",
+    "deploy": "npx rimraf dist-deploy && npm run eleventy -- --pathprefix=/lists/ --output=dist-deploy",
     "eleventy": "npx @11ty/eleventy",
     "prettier": "prettier --write src/",
     "fix": "eslint --fix **/*.js",


### PR DESCRIPTION
Can now use `npm run deploy` to create a deployable version of the site.